### PR TITLE
change name to seneca-sqlite-store

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "seneca-sqlite",
+  "name": "seneca-sqlite-store",
   "version": "0.0.1",
   "description": "SQLite database layer for Seneca framework",
   "main": "lib/sqlite-store.js",
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/bamse16/seneca-sqlite.git"
+    "url": "git://github.com/bamse16/seneca-sqlite-store.git"
   },
   "keywords": [
     "seneca",


### PR DESCRIPTION
we need to give all store plugins the same name style so that they are easy to guess:
seneca-<name>-store

(this is not a "code" convention :) - it's about user interface (the seneca API) consistency)
