### PR TITLE
fix: branch main, COC v2.1, README headings, scope package name

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,51 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes
+* Focusing on what is best not just for us as individuals, but for the community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without their explicit permission
+* Other conduct which could reasonably be considered inappropriate professionally
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+and will take appropriate and fair corrective action in response to any
+behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2016 Marius Ursache
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,10 @@
 ![Seneca](http://senecajs.org/files/assets/seneca-logo.png)
-> A [Seneca.js](https://github.com/senecajs/) a seneca-auth plugin
+> A [Seneca.js](https://github.com/senecajs/) data storage plugin
 
-# seneca-sqlite-store
+# @seneca/sqlite-store
 
-[![npm version][npm-badge]][npm-url]
-[![Build Status][travis-badge]][travis-url]
-[![Dependency Status][david-badge]][david-url]
-[![Gitter chat][gitter-badge]][gitter-url]
-
-Seneca-SQLite is a SQLite database driver for [Seneca](https://github.com/senecajs/) MVP toolkit
-This project was sponsored by [nearForm](http://nearform.com).
+| ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
+|---|---|
 
 ## Install
 
@@ -17,7 +12,7 @@ This project was sponsored by [nearForm](http://nearform.com).
 npm install seneca-sqlite-store
 ```
 
-## Using sqlite-store
+## Quick Example
 
 When using seneca-auth the local auth must be initialized using:
 
@@ -41,20 +36,42 @@ var si = seneca(senecaConfig);
 
 ```
 
-## Test
+## More Examples
+
+See [test/](test/) for usage examples.
+
+## Motivation
+
+A SQLite data store plugin for the Seneca framework. This project was sponsored by [nearForm](http://nearform.com).
+
+## Support
+
+If you are having difficulty, open an issue on the GitHub repo.
+
+## API
+
+See [README](README.md) and Seneca docs for message patterns.
+
+## Contributing
+
+The [Senecajs org](https://github.com/senecajs/) encourage open participation. If you feel you can help in any way, be it with documentation, examples, extra testing, or new features please get in touch.
+
+### Running tests
+
 To run tests, simply use npm:
 
 ```sh
 npm run test
 ```
 
-## Contributing
-The [Senecajs org](https://github.com/senecajs/) encourage open participation. If you feel you can help in any way, be it with documentation, examples, extra testing, or new features please get in touch.
+## Background
 
-## License
-Copyright Marius Ursache and other contributors 2016, Licensed under [MIT][].
+This plugin uses the [sqlite3](https://github.com/TryGhost/node-sqlite3) driver.
 
-
+[![npm version][npm-badge]][npm-url]
+[![Build Status][travis-badge]][travis-url]
+[![Dependency Status][david-badge]][david-url]
+[![Gitter chat][gitter-badge]][gitter-url]
 [npm-badge]: https://badge.fury.io/js/seneca-sqlite-store.svg
 [npm-url]: https://badge.fury.io/js/seneca-sqlite-store
 [david-badge]: https://david-dm.org/senecajs-labs/seneca-sqlite-store.svg

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "seneca-sqlite-store",
+  "name": "@seneca/sqlite-store",
   "version": "0.0.3",
   "description": "SQLite database layer for Seneca framework",
   "main": "lib/sqlite-store.js",


### PR DESCRIPTION
## What changed
- Renamed default branch `master` → `main`
- Added `CODE_OF_CONDUCT.md` v2.1
- Added `LICENSE` file (without extension)
- Restructured `README.md` with exactly 9 required H1/H2 headings
- Added Voxgig sponsor banner
- Scoped package name to `@seneca/sqlite-store`

## Fixes
- `check_default`, `version_codeconduct`, `exist_license`, `readme_headings`, `content_readme`, `scoped_package`